### PR TITLE
Rewrite radio_sender example to use serial.threaded.LineReader

### DIFF
--- a/examples/radio_sender.py
+++ b/examples/radio_sender.py
@@ -1,34 +1,56 @@
 #!/usr/bin/env python3
 import time
-import serial
 import sys
-import argparse
+import serial
+import argparse 
+
+from serial.threaded import LineReader, ReaderThread
 
 parser = argparse.ArgumentParser(description='LoRa Radio mode sender.')
 parser.add_argument('port', help="Serial port descriptor")
 args = parser.parse_args()
 
-def send_cmd(cmd):
-    ser.write(('%s\r\n' % cmd).encode('UTF-8'))
-    # print("device: %s" % ser.readline().decode("UTF-8").strip())
+class PrintLines(LineReader):
 
-with serial.Serial(args.port, 57600, timeout=1) as ser:
-    send_cmd("sys set pindig GPIO11 0")
-    send_cmd('sys get ver')
-    send_cmd('radio get mod')
-    send_cmd('radio get freq')
-    send_cmd('radio get sf')
-    send_cmd('mac pause')
-    send_cmd('radio set pwr 10')
-    send_cmd("sys set pindig GPIO11 0")
+    def connection_made(self, transport):
+        print("connection made")
+        self.transport = transport
+        self.send_cmd("sys set pindig GPIO11 0")
+        self.send_cmd('sys get ver')
+        self.send_cmd('radio get mod')
+        self.send_cmd('radio get freq')
+        self.send_cmd('radio get sf')
+        self.send_cmd('mac pause')
+        self.send_cmd('radio set pwr 10')
+        self.send_cmd("sys set pindig GPIO11 0")
+        self.frame_count = 0
 
-    frame_count = 0
-    while True:
-        send_cmd("sys set pindig GPIO11 1")
-        txmsg = 'radio tx %x%x' % (int(time.time()), frame_count)
-        print(txmsg)
-        send_cmd(txmsg)
+    def handle_line(self, data):
+        if data == "ok":
+            return
+        print("RECV: %s" % data)
+
+    def connection_lost(self, exc):
+        if exc:
+            print(exc)
+        print("port closed")
+
+    def tx(self):
+        self.send_cmd("sys set pindig GPIO11 1")
+        txmsg = 'radio tx %x%x' % (int(time.time()), self.frame_count)
+        self.send_cmd(txmsg)
         time.sleep(.3)
-        send_cmd("sys set pindig GPIO11 0")
-        frame_count = frame_count + 1
+        self.send_cmd("sys set pindig GPIO11 0")
+        self.frame_count = self.frame_count + 1
+
+    def send_cmd(self, cmd, delay=.5):
+        print("SEND: %s" % cmd)
+        self.write_line(cmd)
+        time.sleep(delay)
+
+
+ser = serial.Serial(args.port, baudrate=57600)
+with ReaderThread(ser, PrintLines) as protocol:
+    while(1):
+        protocol.tx()
         time.sleep(10)


### PR DESCRIPTION
First, my apologies - I recognise a PR of "I arbitrarily massively rewrote something" is a little obnoxious...

My two LoStiks just arrived, the blink demo works well, and the send/receive demos _ran_, but with no visible data transfer.

I tried a bunch of stuff, and then decided to rewrite `radio_sender` in the style of `radio_receiver` - using `LineReader` - to make it easier for me to add more debugging `print`s etc.

Lo and behold, I did that, and suddenly I was sending data just fine, despite (as far as I can tell) sending exactly the same commands with exactly the same timing.

So, I completely understand why you might not want this PR - I haven't yet had time to dig deeper into the exact differences that led to behaviour changes and I suspect I won't - but maybe you will, and if nothing else, this worked for me...